### PR TITLE
Feat/repository fix generator

### DIFF
--- a/repository.js
+++ b/repository.js
@@ -33,7 +33,6 @@ export const removeFromLocalStorage = (id) => {
     ls.splice(indexItem, 1);
   }
 
-  console.log(ls)
   insertToLocalStorage(ls);
 };
 

--- a/repository.js
+++ b/repository.js
@@ -7,6 +7,7 @@ export const addToArrayInLocalStorage = (value) => {
   const newItem = {
     id: getNewId(),
     name: value,
+    status: false
   };
 
   currentValue.push(newItem);
@@ -44,5 +45,5 @@ export const getItemById = (id) => {
 
 const getNewId = () => {
     const data = getFromLocalStorage();
-  return data.length + 1;
+  return data ? data.length + 1 : 1;
 };


### PR DESCRIPTION
Fixed function generator id.

Error fixed: When the localStorage was clear (no items) the method `.length` cause TypeError because the data was null/undefined.